### PR TITLE
fix most warnings from `clippy::pedantic` and `clippy::nursery`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! This crate provides two MediaType structs: [`MediaType`] and [`MediaTypeBuf`].
+//! This crate provides two media type structs: [`MediaType`] and [`MediaTypeBuf`].
 //!
 //! - [`MediaType`] does not copy data during parsing
 //!     and borrows the original string. It is also const-constructible.

--- a/src/media_type.rs
+++ b/src/media_type.rs
@@ -1,7 +1,7 @@
 use super::{error::*, media_type_buf::*, name::*, params::*, parse::*, value::*};
 use std::{borrow::Cow, collections::HashMap, fmt};
 
-/// A borrowed MediaType.
+/// A borrowed media type.
 ///
 /// ```
 /// use mediatype::{names::*, MediaType, Value, WriteParams};
@@ -47,6 +47,7 @@ impl<'a> MediaType<'a> {
     /// const IMAGE_PNG: MediaType = MediaType::new(IMAGE, PNG);
     /// assert_eq!(IMAGE_PNG, MediaType::parse("image/png").unwrap());
     /// ```
+    #[must_use]
     pub const fn new(ty: Name<'a>, subty: Name<'a>) -> Self {
         Self {
             ty,
@@ -66,6 +67,7 @@ impl<'a> MediaType<'a> {
     ///     MediaType::parse("image/svg+xml; charset=UTF-8").unwrap()
     /// );
     /// ```
+    #[must_use]
     pub const fn from_parts(
         ty: Name<'a>,
         subty: Name<'a>,
@@ -95,6 +97,10 @@ impl<'a> MediaType<'a> {
     }
 
     /// Constructs a `MediaType` from `str` without copying the string.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the string fails to be parsed.
     pub fn parse<'s: 'a>(s: &'s str) -> Result<Self, MediaTypeError> {
         let (indices, _) = Indices::parse(s)?;
         let params = indices
@@ -127,7 +133,8 @@ impl<'a> MediaType<'a> {
     /// ```
     ///
     /// [`MadiaType`]: ./struct.MediaType.html
-    pub fn essence(&self) -> MediaType<'_> {
+    #[must_use]
+    pub const fn essence(&self) -> MediaType<'_> {
         MediaType::from_parts(self.ty, self.subty, self.suffix, &[])
     }
 }

--- a/src/media_type_buf.rs
+++ b/src/media_type_buf.rs
@@ -1,7 +1,7 @@
 use super::{error::*, media_type::*, name::*, params::*, parse::*, value::*};
 use std::{borrow::Cow, collections::HashMap, fmt, str::FromStr};
 
-/// An owned and immutable [`MediaType`].
+/// An owned and immutable media type.
 ///
 /// ```
 /// use mediatype::{names::*, values::*, MediaType, MediaTypeBuf, ReadParams};

--- a/src/media_type_buf.rs
+++ b/src/media_type_buf.rs
@@ -1,7 +1,7 @@
 use super::{error::*, media_type::*, name::*, params::*, parse::*, value::*};
 use std::{borrow::Cow, collections::HashMap, fmt, str::FromStr};
 
-/// An owned and immutable MediaType.
+/// An owned and immutable [`MediaType`].
 ///
 /// ```
 /// use mediatype::{names::*, values::*, MediaType, MediaTypeBuf, ReadParams};
@@ -21,11 +21,13 @@ pub struct MediaTypeBuf {
 
 impl MediaTypeBuf {
     /// Constructs a `MediaTypeBuf` from a top-level type and a subtype.
+    #[must_use]
     pub fn new(ty: Name, subty: Name) -> Self {
-        Self::from_string(format!("{}/{}", ty, subty)).unwrap()
+        Self::from_string(format!("{}/{}", ty, subty)).expect("`ty` and `subty` should be valid")
     }
 
     /// Constructs a `MediaTypeBuf` with an optional suffix and parameters.
+    #[must_use]
     pub fn from_parts(
         ty: Name,
         subty: Name,
@@ -34,20 +36,24 @@ impl MediaTypeBuf {
     ) -> Self {
         use std::fmt::Write;
         let mut s = String::new();
-        write!(s, "{}/{}", ty, subty).unwrap();
+        write!(s, "{}/{}", ty, subty).expect("`ty` and `subty` should be valid");
         if let Some(suffix) = suffix {
             write!(s, "+{}", suffix).unwrap();
         }
         for (name, value) in params {
             write!(s, "; {}={}", name, value).unwrap();
         }
-        Self::from_string(s).unwrap()
+        Self::from_string(s).expect("all values should be valid")
     }
 
     /// Constructs a `MediaTypeBuf` from [`String`].
     ///
     /// Unlike [`FromStr::from_str`], this function takes the ownership of [`String`]
     /// instead of making a new copy.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the string fails to be parsed.
     ///
     /// [`String`]: https://doc.rust-lang.org/std/string/struct.String.html
     /// [`FromStr::from_str`]: https://doc.rust-lang.org/std/str/trait.FromStr.html
@@ -61,16 +67,19 @@ impl MediaTypeBuf {
     }
 
     /// Returns the top-level type.
+    #[must_use]
     pub fn ty(&self) -> Name {
         Name::new_unchecked(&self.data[self.indices.ty()])
     }
 
     /// Returns the subtype.
+    #[must_use]
     pub fn subty(&self) -> Name {
         Name::new_unchecked(&self.data[self.indices.subty()])
     }
 
     /// Returns the suffix.
+    #[must_use]
     pub fn suffix(&self) -> Option<Name> {
         self.indices
             .suffix()
@@ -87,12 +96,14 @@ impl MediaTypeBuf {
     /// ```
     ///
     /// [`MadiaType`]: ./struct.MediaType.html
+    #[must_use]
     pub fn essence(&self) -> MediaType<'_> {
         MediaType::from_parts(self.ty(), self.subty(), self.suffix(), &[])
     }
 
     /// Returns the underlying string.
-    pub fn as_str(&self) -> &str {
+    #[must_use]
+    pub const fn as_str(&self) -> &str {
         &self.data
     }
 
@@ -108,6 +119,7 @@ impl MediaTypeBuf {
     ///     "image/svg+xml; charset=UTF-8"
     /// );
     /// ```
+    #[must_use]
     pub fn canonicalize(&self) -> Self {
         use std::fmt::Write;
         let mut s = String::with_capacity(self.data.len());
@@ -119,20 +131,23 @@ impl MediaTypeBuf {
         )
         .unwrap();
         if let Some(suffix) = self.suffix() {
-            write!(s, "+{}", suffix.as_str().to_ascii_lowercase()).unwrap();
+            write!(s, "+{}", suffix.as_str().to_ascii_lowercase())
+                .expect("`write` should not fail on a `String`");
         }
         for (name, value) in self.params() {
-            write!(s, "; {}={}", name.as_str().to_ascii_lowercase(), value).unwrap();
+            write!(s, "; {}={}", name.as_str().to_ascii_lowercase(), value)
+                .expect("`write` should not fail on a `String`");
         }
         s.shrink_to_fit();
-        Self::from_string(s).unwrap()
+        Self::from_string(s).expect("all values should be valid")
     }
 
     /// Constructs a `MediaType` from `self`.
+    #[must_use]
     pub fn to_ref(&self) -> MediaType {
         let params = self.params().collect::<Vec<_>>();
         let params = if params.is_empty() {
-            Cow::Borrowed(&[][..])
+            Cow::Borrowed([].as_slice())
         } else {
             Cow::Owned(params)
         };
@@ -173,13 +188,13 @@ impl FromStr for MediaTypeBuf {
 
 impl From<MediaType<'_>> for MediaTypeBuf {
     fn from(t: MediaType) -> Self {
-        Self::from_string(t.to_string()).unwrap()
+        Self::from_string(t.to_string()).expect("`t` should be valid")
     }
 }
 
 impl From<&MediaType<'_>> for MediaTypeBuf {
     fn from(t: &MediaType) -> Self {
-        Self::from_string(t.to_string()).unwrap()
+        Self::from_string(t.to_string()).expect("`t` should be valid")
     }
 }
 

--- a/src/name.rs
+++ b/src/name.rs
@@ -20,6 +20,7 @@ impl<'a> Name<'a> {
     /// Constructs a `Name`.
     ///
     /// If the string is not valid as a name, returns `None`.
+    #[must_use]
     pub fn new(s: &'a str) -> Option<Self> {
         if is_restricted_name(s) {
             Some(Self(s))
@@ -29,7 +30,8 @@ impl<'a> Name<'a> {
     }
 
     /// Returns the underlying string.
-    pub fn as_str(&self) -> &str {
+    #[must_use]
+    pub const fn as_str(&self) -> &str {
         self.0
     }
 

--- a/src/params.rs
+++ b/src/params.rs
@@ -8,14 +8,14 @@ pub struct Params<'a> {
 }
 
 impl<'a> Params<'a> {
-    pub(crate) fn from_slice(s: &'a [(Name<'a>, Value<'a>)]) -> Self {
+    pub(crate) const fn from_slice(s: &'a [(Name<'a>, Value<'a>)]) -> Self {
         Self {
             source: ParamsSource::Slice(s),
             index: 0,
         }
     }
 
-    pub(crate) fn from_indices(s: &'a str, i: &'a Indices) -> Self {
+    pub(crate) const fn from_indices(s: &'a str, i: &'a Indices) -> Self {
         Self {
             source: ParamsSource::Indices(s, i),
             index: 0,

--- a/src/value.rs
+++ b/src/value.rs
@@ -32,6 +32,7 @@ impl<'a> Value<'a> {
     /// Constructs a `Value`.
     ///
     /// If the string is not valid as a value, returns `None`.
+    #[must_use]
     pub fn new(s: &'a str) -> Option<Self> {
         if let Some(quoted) = s.strip_prefix('\"') {
             if quoted.len() > 1 && parse_quoted_value(quoted) == Ok(quoted.len()) {
@@ -44,11 +45,13 @@ impl<'a> Value<'a> {
     }
 
     /// Returns the underlying string.
-    pub fn as_str(&self) -> &str {
+    #[must_use]
+    pub const fn as_str(&self) -> &str {
         self.0
     }
 
     /// Returns the unquoted string.
+    #[must_use]
     pub fn unquoted_str(&self) -> Cow<'_, str> {
         if self.0.starts_with('"') {
             let inner = &self.0[1..self.0.len() - 1];
@@ -89,6 +92,7 @@ impl<'a> Value<'a> {
     ///     "\" \\\"What's wrong\\?\\\" \""
     /// );
     /// ```
+    #[must_use]
     pub fn quote(s: &str) -> Cow<'_, str> {
         if is_restricted_str(s) {
             Cow::Borrowed(s)


### PR DESCRIPTION
i intentionally did not fix errors that would change any names (e.g. module name reptition in types), and those complaining about wildcard imports (in internal code it's fine).