### PR TITLE
Updated Value::as_str to return the proper lifetime for the str reference

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -46,7 +46,7 @@ impl<'a> Value<'a> {
 
     /// Returns the underlying string.
     #[must_use]
-    pub const fn as_str(&self) -> &str {
+    pub const fn as_str(&self) -> &'a str {
         self.0
     }
 


### PR DESCRIPTION
The reference that is returned by `Value::as_str` should have the lifetime of the str reference in the struct, not the lifetime of self (this is the inferred lifetime if left out).