### PR TITLE
Fix Deserialize impl to make input lifetime less constrained

### DIFF
--- a/src/serde.rs
+++ b/src/serde.rs
@@ -13,7 +13,7 @@ impl<'a> Serialize for MediaType<'a> {
     }
 }
 
-impl<'de> Deserialize<'de> for MediaType<'de> {
+impl<'de: 'a, 'a> Deserialize<'de> for MediaType<'a> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,


### PR DESCRIPTION
Mediatype's current signature for the Deserialize impl is exactly what https://serde.rs/lifetimes.html says not to do.

> The `'de` lifetime **should not** appear in the type to which the `Deserialize` impl applies.
>
> ```diff
> - // Do not do this. Sooner or later you will be sad.
> - impl<'de> Deserialize<'de> for Q<'de> {
>
> + // Do this instead.
> + impl<'de: 'a, 'a> Deserialize<'de> for Q<'a> {
> ```

Example code:

```rust
use mediatype::MediaType;
use serde_derive::Deserialize;
use std::path::PathBuf;
use std::time::SystemTime;

#[derive(Deserialize)]
pub struct FileMetadata<'a> {
    pub file_path: PathBuf,
    pub last_updated: SystemTime,
    #[serde(borrow)]
    pub mediatype: MediaType<'a>,
}
```

Without this PR:

```console
error: lifetime may not live long enough
  --> src/main.rs:10:5
   |
6  |   #[derive(Deserialize)]
   |            ----------- lifetime `'de` defined here
7  |   pub struct FileMetadata<'a> {
   |                           -- lifetime `'a` defined here
...
10 | /     #[serde(borrow)]
11 | |     pub mediatype: MediaType<'a>,
   | |________________________________^ requires that `'a` must outlive `'de`
   |
   = help: consider adding the following bound: `'a: 'de`
```

After this PR: works.