### PR TITLE
Add rss, feed to names.txt

### DIFF
--- a/src/consts/names.txt
+++ b/src/consts/names.txt
@@ -206,6 +206,7 @@ express
 fastinfoset
 fastsoap
 fdt
+feed
 FFV1
 fhir
 fhirpath
@@ -536,6 +537,7 @@ rpki-manifest
 rpki-publication
 rpki-roa
 rpki-updown
+rss
 rtf
 rtp-enc-aescm128
 rtp-midi


### PR DESCRIPTION
application/rss+xml did not make it to IANA but is used, discussions:

https://stackoverflow.com/questions/595616/what-is-the-correct-mime-type-to-use-for-an-rss-feed https://www.petefreitag.com/blog/content-type-xml-feeds/

application/feed+json is also not (yet?) official: https://www.jsonfeed.org/