### PR TITLE
Add `no_std` support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,3 +30,7 @@ jobs:
       run: cargo build --all-features --verbose
     - name: Run tests
       run: cargo test --all-features --verbose
+    - name: Test no_std support
+      run: |
+        rustup target add thumbv6m-none-eabi
+        cargo build --verbose --release --no-default-features --target thumbv6m-none-eabi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
-serde = { version = "1.0.144", optional = true, default-features = false }
+serde = { version = "1.0.144", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 serde_json = "1.0.85"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
-serde = { version = "1.0.144", optional = true }
+serde = { version = "1.0.144", optional = true, default-features = false }
 
 [dev-dependencies]
 serde_json = "1.0.85"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use std::{error, fmt};
+use core::{error, fmt};
 
 /// Media-type format error.
 #[non_exhaustive]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! This crate provides two media type structs: [`MediaType`] and [`MediaTypeBuf`].
 //!
 //! - [`MediaType`] does not copy data during parsing
-//!     and borrows the original string. It is also const-constructible.
+//!   and borrows the original string. It is also const-constructible.
 //! - [`MediaTypeBuf`] is an owned  and immutable version of [`MediaType`].
 //!
 //! [`MadiaType`]: ./struct.MediaType.html
@@ -38,9 +38,15 @@
 //! assert_eq!(upper.subty(), "Plain");
 //! ```
 
+#![no_std]
 #![forbid(unsafe_code)]
 #![forbid(clippy::all)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+
+extern crate alloc;
+
+#[cfg(test)]
+extern crate std;
 
 mod consts;
 mod error;

--- a/src/media_type.rs
+++ b/src/media_type.rs
@@ -1,7 +1,6 @@
 use super::{error::*, media_type_buf::*, name::*, params::*, parse::*, value::*};
-use std::{
-    borrow::Cow,
-    collections::BTreeMap,
+use alloc::{borrow::Cow, collections::BTreeMap, vec::Vec};
+use core::{
     fmt,
     hash::{Hash, Hasher},
 };
@@ -243,8 +242,9 @@ impl Hash for MediaType<'_> {
 mod tests {
     use super::*;
     use crate::{names::*, values::*};
+    use alloc::string::ToString;
+    use core::str::FromStr;
     use std::collections::hash_map::DefaultHasher;
-    use std::str::FromStr;
 
     fn calculate_hash<T: Hash>(t: &T) -> u64 {
         let mut s = DefaultHasher::new();

--- a/src/media_type_buf.rs
+++ b/src/media_type_buf.rs
@@ -1,7 +1,12 @@
 use super::{error::*, media_type::*, name::*, params::*, parse::*, value::*};
-use std::{
+use alloc::{
     borrow::Cow,
+    boxed::Box,
     collections::BTreeMap,
+    string::{String, ToString},
+    vec::Vec,
+};
+use core::{
     fmt,
     hash::{Hash, Hasher},
     str::FromStr,
@@ -29,7 +34,8 @@ impl MediaTypeBuf {
     /// Constructs a `MediaTypeBuf` from a top-level type and a subtype.
     #[must_use]
     pub fn new(ty: Name, subty: Name) -> Self {
-        Self::from_string(format!("{}/{}", ty, subty)).expect("`ty` and `subty` should be valid")
+        Self::from_string([ty.as_str(), "/", subty.as_str()].concat())
+            .expect("`ty` and `subty` should be valid")
     }
 
     /// Constructs a `MediaTypeBuf` with an optional suffix and parameters.
@@ -40,7 +46,7 @@ impl MediaTypeBuf {
         suffix: Option<Name>,
         params: &[(Name, Value)],
     ) -> Self {
-        use std::fmt::Write;
+        use core::fmt::Write;
         let mut s = String::new();
         write!(s, "{}/{}", ty, subty).expect("`ty` and `subty` should be valid");
         if let Some(suffix) = suffix {
@@ -127,7 +133,7 @@ impl MediaTypeBuf {
     /// ```
     #[must_use]
     pub fn canonicalize(&self) -> Self {
-        use std::fmt::Write;
+        use core::fmt::Write;
         let mut s = String::with_capacity(self.data.len());
         write!(
             s,
@@ -274,6 +280,7 @@ impl Hash for MediaTypeBuf {
 mod tests {
     use super::*;
     use crate::{media_type, names::*, values::*};
+    use alloc::string::ToString;
     use std::collections::hash_map::DefaultHasher;
 
     fn calculate_hash<T: Hash>(t: &T) -> u64 {

--- a/src/name.rs
+++ b/src/name.rs
@@ -1,8 +1,7 @@
 use super::parse::*;
-use std::{
-    borrow::Cow,
+use alloc::{borrow::Cow, fmt, string::String};
+use core::{
     cmp::Ordering,
-    fmt,
     hash::{Hash, Hasher},
 };
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,5 +1,6 @@
 use super::{error::*, name::*};
-use std::{num::NonZeroU8, ops::Range};
+use alloc::{boxed::Box, vec::Vec};
+use core::{num::NonZeroU8, ops::Range};
 
 #[derive(Debug, Clone)]
 pub struct Indices {
@@ -92,10 +93,10 @@ impl Indices {
 }
 
 #[cfg(test)]
-fn parse_to_string(s: &str) -> Result<String, MediaTypeError> {
-    use std::fmt::Write;
+fn parse_to_string(s: &str) -> Result<alloc::string::String, MediaTypeError> {
+    use core::fmt::Write;
 
-    let mut out = String::new();
+    let mut out = alloc::string::String::new();
     let (indices, _) = Indices::parse(s)?;
 
     write!(out, "{}/{}", &s[indices.ty()], &s[indices.subty()]).unwrap();
@@ -265,11 +266,11 @@ mod tests {
         );
 
         let s = "text/plain";
-        let long_str = format!("{};{}", s, " ".repeat(u16::MAX as usize - 2 - s.len()));
+        let long_str = [s, ";", &" ".repeat(u16::MAX as usize - 2 - s.len())].concat();
         assert_eq!(parse_to_string(&long_str), Ok("text/plain".into()));
 
         let long_name = "a".repeat(Name::MAX_LENGTH);
-        let long_str = format!("{}/{}+{}", long_name, long_name, long_name);
+        let long_str = [&long_name, "/", &long_name, "+", &long_name].concat();
         assert_eq!(parse_to_string(&long_str), Ok(long_str));
     }
 
@@ -313,7 +314,7 @@ mod tests {
             Err(MediaTypeError::InvalidParamName)
         );
 
-        let long_str = format!("{}/plain", "t".repeat(u16::MAX as usize));
+        let long_str = [&"t".repeat(u16::MAX as usize), "/plain"].concat();
         assert_eq!(
             parse_to_string(&long_str),
             Err(MediaTypeError::InvalidTypeName)

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,8 +1,8 @@
 #![cfg(feature = "serde")]
 
 use super::{media_type::*, media_type_buf::*};
+use alloc::{borrow::Cow, string::ToString};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::borrow::Cow;
 
 impl Serialize for MediaType<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -47,8 +47,8 @@ impl<'de> Deserialize<'de> for MediaTypeBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::str::FromStr;
     use serde_json::Value;
-    use std::str::FromStr;
 
     #[test]
     fn serde() {

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,8 +1,7 @@
 use super::parse::*;
-use std::{
-    borrow::Cow,
+use alloc::{borrow::Cow, fmt, string::String, vec};
+use core::{
     cmp::Ordering,
-    fmt,
     hash::{Hash, Hasher},
     iter,
 };


### PR DESCRIPTION
i'm trying to use this crate in a no_std package, but the references to `std` are a bit of a holdback. since in this case the only `std` uses are re-exports from `alloc` and `core`, the references can largely be replaced wholesale.

I tested this locally in another crate, and compiled against a target without `std` support (`thumbv6m-none-eabi`), and the unit tests seem to pass, so hopefully it all works! (sorry for the slight maintenance burden going forward to implement features without `std`, but a feature flag could be added instead if need be)

I also added a CI test to check that this still builds in a no_std environment