### PR TITLE
Value::new_unchecked should be public

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -108,7 +108,7 @@ impl<'a> Value<'a> {
         }
     }
 
-    pub(crate) const fn new_unchecked(s: &'a str) -> Self {
+    pub const fn new_unchecked(s: &'a str) -> Self {
         Self(s)
     }
 }


### PR DESCRIPTION
Closes #26

You cannot construct const media types using `MediaType::from_parts` without using the `Value::new_unchecked`.

```rs
use mediatype::MediaType;

const MULTIPART_WITH_SPEC: MediaType = MediaType::from_parts(
    mediatype::names::MULTIPART,
    mediatype::names::MIXED,
    None,
    &[(
        mediatype::Name::new_unchecked("spec"),
        // ⚠️             vvvvvvvvvvvvv must to be public
        mediatype::Value::new_unchecked("1.0"),
    )],
);
```