### PR TITLE
Reject CR in quoted-string parameter values per RFC 7230

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -211,7 +211,11 @@ pub fn parse_quoted_value(s: &str) -> Result<usize, MediaTypeError> {
                 escaped = true;
             }
             '"' => return Ok(len),
-            '\n' => return Err(MediaTypeError::InvalidParamValue),
+            // RFC 7230 §3.2.6: qdtext excludes all CTLs except HTAB; CR and LF are
+            // both forbidden. Rejecting '\r' alongside '\n' closes a CRLF-injection
+            // vector (raw CR was accepted by the catch-all below and round-tripped
+            // verbatim through Display on re-serialization).
+            '\n' | '\r' => return Err(MediaTypeError::InvalidParamValue),
             _ => (),
         }
     }
@@ -332,6 +336,47 @@ mod tests {
         assert_eq!(
             parse_to_string("text/plain; кодування=UTF-8"),
             Err(MediaTypeError::InvalidParamName)
+        );
+    }
+
+    // RFC 7230 §3.2.6: qdtext = HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text;
+    // all CTLs except HTAB are excluded from a quoted-string value. CR and LF are
+    // both forbidden — the parser must reject them symmetrically (an incomplete
+    // CTL filter that rejects only LF and admits CR is a CRLF-injection vector:
+    // the parsed MediaType borrows the input, so a raw CR is round-tripped
+    // verbatim through Display on re-serialization into an HTTP header).
+    #[test]
+    fn parse_quoted_value_ctl_filter() {
+        // HTAB is the only CTL allowed in qdtext (RFC 7230 §3.2.6) — must parse.
+        assert_eq!(
+            parse_to_string("text/plain; x=\"foo\tbar\""),
+            Ok("text/plain; x=\"foo\tbar\"".into())
+        );
+        // SP is valid qdtext — must parse.
+        assert_eq!(
+            parse_to_string("text/plain; x=\"foo bar\""),
+            Ok("text/plain; x=\"foo bar\"".into())
+        );
+        // A regular VCHAR quoted value — must parse (control).
+        assert_eq!(
+            parse_to_string("text/plain; charset=\"UTF-8\""),
+            Ok("text/plain; charset=\"UTF-8\"".into())
+        );
+        // Raw CR inside a quoted value is invalid qdtext — must be rejected.
+        assert_eq!(
+            parse_to_string("text/plain; x=\"foo\rbar\""),
+            Err(MediaTypeError::InvalidParamValue)
+        );
+        // Raw LF inside a quoted value is invalid qdtext — must be rejected
+        // (symmetry with the CR case: RFC 7230 treats CR and LF identically).
+        assert_eq!(
+            parse_to_string("text/plain; x=\"foo\nbar\""),
+            Err(MediaTypeError::InvalidParamValue)
+        );
+        // CRLF inside a quoted value — must be rejected (CR is hit first).
+        assert_eq!(
+            parse_to_string("text/plain; x=\"foo\r\nbar\""),
+            Err(MediaTypeError::InvalidParamValue)
         );
     }
 }


### PR DESCRIPTION
## Problem

`parse_quoted_value` special-cases `'\n'` (LF) and returns `Err(InvalidParamValue)`, but the catch-all `_ => ()` arm accepts `'\r'` (CR) and all other CTLs as `qdtext` -- an incomplete control-character filter. Per RFC 7230 section 3.2.6, `qdtext` excludes all CTLs except HTAB (CR is forbidden); per RFC 2045 section 5.1 `qtext` explicitly excludes CR.

Because the parser is zero-copy, `Display`/`to_string` round-trips the raw CR byte verbatim: `text/plain; x="foo\rbar"` parses to `Ok` and re-serializes with the raw CR intact -- a CRLF/header-splitting vector when a parsed `MediaType` is written into a response header.

## Evidence

- mediatype: `text/plain; x="foo\rbar"` -> **Ok**, `to_string()` preserves raw CR.
- Go stdlib `mime.ParseMediaType` -> **REJECT** ("mime: invalid media parameter").
- Asymmetry: mediatype rejects `x="foo\nbar"` (LF) but accepts `x="foo\rbar"` (CR); RFC treats CR and LF identically, so the split is unambiguously the incomplete filter.

## Fix

Widen the existing reject arm to also reject `'\r'`: `'\n' | '\r' => return Err(MediaTypeError::InvalidParamValue)`. Minimal, style-matching, with an RFC-citing comment. Catch-all and quoted-pair arms unchanged (out of scope).

## Tests

`cargo test --all-features`: 42 passed (27 unit incl. new test + 1 codegen + 14 doc-tests). `cargo fmt --check` clean on touched file. Clippy: 0 new warnings/errors vs HEAD. New test `parse_quoted_value_ctl_filter` (HTAB/SP/VCHAR valid -> Ok; raw CR/LF/CRLF -> Err). Pre-fix: fails (`Ok(...)` when `Err` expected for CR); post-fix: pass. Harness re-run on fixed code: CR and LF both rejected symmetrically; 0 accepts of raw CR (was 1).

Out of scope: NUL/DEL among CTLs (Go `mime` is also lenient on those).