### PR TITLE
Fix panic on single-character structured syntax suffix

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -61,7 +61,7 @@ impl Indices {
             return Err(MediaTypeError::InvalidSubtypeName);
         }
 
-        if !suffix.is_empty() && !is_restricted_name(&suffix[1..]) {
+        if !suffix.is_empty() && !is_restricted_name(suffix) {
             return Err(MediaTypeError::InvalidSuffix);
         }
 
@@ -232,6 +232,8 @@ mod tests {
         assert_eq!(parse_to_string("text/plain"), Ok("text/plain".into()));
         assert_eq!(parse_to_string("text/plain;"), Ok("text/plain".into()));
         assert_eq!(parse_to_string("image/svg+xml"), Ok("image/svg+xml".into()));
+        assert_eq!(parse_to_string("image/svg+x"), Ok("image/svg+x".into()));
+        assert_eq!(parse_to_string("a/b+c+d"), Ok("a/b+c+d".into()));
         assert_eq!(
             parse_to_string("image/svg+xml;"),
             Ok("image/svg+xml".into())


### PR DESCRIPTION
`MediaType::parse` and everything that routes through it (`MediaTypeBuf::from_parts`, `MediaTypeBuf::from(MediaType)`, `MediaTypeBuf::from_str`) panic on a one-character structured syntax suffix like `image/svg+x`, and reject strings the crate itself emits. `parse.rs:57` already slices the suffix without the leading `+`, but the validation on line 64 sliced it again with `&suffix[1..]`, so a single-char suffix was validated as the empty string (`is_restricted_name("") == false` -> `InvalidSuffix`). Fixed to validate `suffix` directly and added regression cases (`image/svg+x`, `a/b+c+d`). Closes #29.
