### PR TITLE
Reject backslash-escaped CR/LF in quoted parameter values (fixes #30)

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -204,6 +204,12 @@ pub fn parse_quoted_value(s: &str) -> Result<usize, MediaTypeError> {
     for c in s.chars() {
         len += c.len_utf8();
         match c {
+            // RFC 7230 §3.2.6: CR and LF are neither qdtext nor a valid quoted-pair,
+            // so they are forbidden regardless of a preceding backslash. This arm must
+            // precede the `escaped` catch-all below; otherwise an escaped CR/LF is
+            // consumed as a quoted-pair and round-trips verbatim through Display,
+            // opening a CRLF-injection vector on re-serialization.
+            '\n' | '\r' => return Err(MediaTypeError::InvalidParamValue),
             _ if escaped => {
                 escaped = false;
             }
@@ -211,11 +217,6 @@ pub fn parse_quoted_value(s: &str) -> Result<usize, MediaTypeError> {
                 escaped = true;
             }
             '"' => return Ok(len),
-            // RFC 7230 §3.2.6: qdtext excludes all CTLs except HTAB; CR and LF are
-            // both forbidden. Rejecting '\r' alongside '\n' closes a CRLF-injection
-            // vector (raw CR was accepted by the catch-all below and round-tripped
-            // verbatim through Display on re-serialization).
-            '\n' | '\r' => return Err(MediaTypeError::InvalidParamValue),
             _ => (),
         }
     }

--- a/tests/escaped_ctl_repro.rs
+++ b/tests/escaped_ctl_repro.rs
@@ -1,0 +1,69 @@
+//! Regression test for issue #30: an *escaped* CR/LF inside a quoted parameter
+//! value must be rejected, not just a raw CR/LF.
+//!
+//! RFC 7230 §3.2.6: CR and LF are neither `qdtext` nor a valid `quoted-pair`, so
+//! a backslash in front of them does not make them legal. Before the fix the
+//! `_ if escaped` catch-all in `parse_quoted_value` preceded the CR/LF rejection
+//! arm, so a `\` immediately before a CR/LF caused the control character to be
+//! consumed as a quoted-pair and round-tripped verbatim through `Display` — a
+//! CRLF-injection vector. PR #28 added the CR/LF arm but only exercised the raw
+//! form, so the escaped form regressed silently.
+
+use mediatype::{MediaType, MediaTypeBuf, MediaTypeError};
+
+// `text/plain; x="a\<LF>Injected: yes"` — a real backslash followed by a real
+// LF inside the quoted value. `\\` is a literal backslash, `\n` is a literal LF.
+const ESCAPED_LF: &str = "text/plain; x=\"a\\\nInjected: yes\"";
+// The escaped-CR variant: a real backslash followed by a real CR.
+const ESCAPED_CR: &str = "text/plain; x=\"a\\\rInjected: yes\"";
+// A legitimate escaped-quote quoted value: `text/plain; x="a\"b"`.
+const ESCAPED_QUOTE: &str = "text/plain; x=\"a\\\"b\"";
+
+#[test]
+fn media_type_parse_rejects_escaped_lf() {
+    assert!(matches!(
+        MediaType::parse(ESCAPED_LF),
+        Err(MediaTypeError::InvalidParamValue)
+    ));
+}
+
+#[test]
+fn media_type_parse_rejects_escaped_cr() {
+    assert!(matches!(
+        MediaType::parse(ESCAPED_CR),
+        Err(MediaTypeError::InvalidParamValue)
+    ));
+}
+
+#[test]
+fn media_type_buf_rejects_escaped_lf() {
+    assert!(matches!(
+        MediaTypeBuf::from_string(ESCAPED_LF.to_string()),
+        Err(MediaTypeError::InvalidParamValue)
+    ));
+    assert!(matches!(
+        ESCAPED_LF.parse::<MediaTypeBuf>(),
+        Err(MediaTypeError::InvalidParamValue)
+    ));
+}
+
+#[test]
+fn media_type_buf_rejects_escaped_cr() {
+    assert!(matches!(
+        MediaTypeBuf::from_string(ESCAPED_CR.to_string()),
+        Err(MediaTypeError::InvalidParamValue)
+    ));
+    assert!(matches!(
+        ESCAPED_CR.parse::<MediaTypeBuf>(),
+        Err(MediaTypeError::InvalidParamValue)
+    ));
+}
+
+#[test]
+fn escaped_quote_still_parses() {
+    // The fix must not regress legitimate quoted-pairs: `\"` is a valid escaped
+    // quote and the value must still parse through both APIs.
+    assert!(MediaType::parse(ESCAPED_QUOTE).is_ok());
+    assert!(MediaTypeBuf::from_string(ESCAPED_QUOTE.to_string()).is_ok());
+    assert!(ESCAPED_QUOTE.parse::<MediaTypeBuf>().is_ok());
+}


### PR DESCRIPTION
Fixes #30.

## Root cause
In `parse_quoted_value` (`src/parse.rs`), the `_ if escaped` catch-all match arm was ordered *before* the `'\n' | '\r'` rejection arm. Because a preceding `\` sets `escaped = true`, a following raw CR or LF was claimed by the escaped catch-all and never validated. An escaped CR/LF (`\` then CR/LF) therefore bypassed validation and survived into `Display`/`as_str`, round-tripping verbatim on re-serialization -- a CRLF-injection vector when the value is written back into an HTTP header.

RFC 7230 §3.2.6: CR and LF are neither `qdtext` nor a valid `quoted-pair`, so a backslash in front of them does not make them legal.

PR #28 added the CR/LF rejection arm but only tested the **raw** form, so the **escaped** form regressed silently.

## Fix
Move the `'\n' | '\r' => Err(InvalidParamValue)` arm *above* the `_ if escaped` catch-all, so CR/LF is rejected regardless of escaping. Reorder-only; no behavior change for any other input.

## Tests
New integration test `tests/escaped_ctl_repro.rs`:
- `MediaType::parse` and `MediaTypeBuf` (`from_string` + `FromStr`) now **reject** `text/plain; x="a\<LF>Injected: yes"` and the escaped-CR variant.
- A legitimate escaped-quote value `text/plain; x="a\"b"` still **parses** through both APIs (no regression to valid quoted-pairs).

Red/green verified: with the arms in the old order the four reject assertions fail; with the fix all pass. Full suite (`cargo test --all-features`) and `cargo clippy --all-features -- -D warnings` are clean.

---
This change was prepared with AI assistance and reviewed by me before submission.